### PR TITLE
Some initial work on the layout components

### DIFF
--- a/crates/belly_widgets/src/layout.rs
+++ b/crates/belly_widgets/src/layout.rs
@@ -1,0 +1,80 @@
+use belly_core::build::*;
+use belly_macro::*;
+use bevy::prelude::*;
+
+#[doc(hidden)]
+pub(crate) struct LayoutPlugin;
+
+pub mod prelude {
+  pub use super::RowWidgetExtension;
+  pub use super::ColumnWidgetExtension;
+  pub use super::CenterWidgetExtension;
+  pub use super::WrapWidgetExtension;
+}
+
+impl Plugin for LayoutPlugin {
+  fn build(&self, app: &mut App) {
+      app.register_widget::<RowWidget>();
+      app.register_widget::<ColumnWidget>();
+      app.register_widget::<CenterWidget>();
+      app.register_widget::<WrapWidget>();
+  }
+}
+
+#[widget]
+#[styles(
+    row {
+      flex-direction: row;
+      justify-content: space-around;
+      align-content: center;
+    }
+)]
+fn row(ctx: &mut WidgetContext) {
+    let content = ctx.content();
+    ctx.insert(ElementBundle::default())
+        .insert(Interaction::None)
+        .push_children(&content);
+}
+
+#[widget]
+#[styles(
+    column {
+      flex-direction: column;
+      justify-content: space-around;
+      align-content: center;
+    }
+)]
+fn column(ctx: &mut WidgetContext) {
+    let content = ctx.content();
+    ctx.insert(ElementBundle::default())
+        .insert(Interaction::None)
+        .push_children(&content);
+}
+
+#[widget]
+#[styles(
+    center {
+      justify-content: center;
+      align-content: center;
+    }
+)]
+fn center(ctx: &mut WidgetContext) {
+    let content = ctx.content();
+    ctx.insert(ElementBundle::default())
+        .insert(Interaction::None)
+        .push_children(&content);
+}
+
+#[widget]
+#[styles(
+    wrap {
+      justify-content: center;
+      align-content: center;
+    }
+)]
+fn wrap(ctx: &mut WidgetContext) {
+    let content = ctx.content();
+    ctx.insert(ElementBundle::default())
+        .insert(Interaction::None)
+        .push_children(&content);
+}

--- a/crates/belly_widgets/src/lib.rs
+++ b/crates/belly_widgets/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod common;
+pub mod layout;
 pub mod img;
 pub mod input;
 pub mod range;
@@ -10,6 +11,7 @@ pub struct WidgetsPlugin;
 impl Plugin for WidgetsPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
         app.add_plugin(common::CommonsPlugin);
+        app.add_plugin(layout::LayoutPlugin);
         app.add_plugin(range::RangePlugin);
         app.add_plugin(img::ImgPlugin);
         app.add_plugin(input::InputPlugins);
@@ -18,6 +20,7 @@ impl Plugin for WidgetsPlugin {
 
 pub mod prelude {
     pub use crate::common::prelude::*;
+    pub use crate::layout::prelude::*;
     pub use crate::img::prelude::*;
     pub use crate::input::prelude::*;
 }

--- a/examples/layout-widgets.rs
+++ b/examples/layout-widgets.rs
@@ -13,7 +13,7 @@ fn main() {
 }
 
 struct MyEvent {
-    emited_at: f32,
+    emitted_at: f32,
 }
 
 #[derive(Component, Default)]
@@ -91,6 +91,6 @@ fn greet(mut greets: Query<&mut Greet, Changed<Greet>>) {
 
 fn debug_my_event(mut events: EventReader<MyEvent>) {
     for event in events.iter() {
-        info!("MyEvent emitted at {:0.2}", event.emited_at);
+        info!("MyEvent emitted at {:0.2}", event.emitted_at);
     }
 }

--- a/examples/layout-widgets.rs
+++ b/examples/layout-widgets.rs
@@ -1,0 +1,96 @@
+use belly::prelude::*;
+use bevy::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(BellyPlugin)
+        .add_event::<MyEvent>()
+        .add_startup_system(setup)
+        .add_system(greet)
+        .add_system(debug_my_event)
+        .run();
+}
+
+struct MyEvent {
+    emited_at: f32,
+}
+
+#[derive(Component, Default)]
+struct Greet {
+    counter: i32,
+    // instead of using text message field here with
+    // custom (greet) system, we should be able to
+    // transform type in bind declaration
+    // TODO: link github issue here
+    message: String,
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2dBundle::default());
+
+    commands.add(eml! {
+        <body>
+            <row>
+                <column s:padding="25px" s:margin="5px" s:background-color="white">
+                    <span>"Row 1 Column 1"</span>
+                    <button on:press=|ctx| info!("I was pressed at {}", ctx.time().elapsed_seconds())>
+                        "1. Press me and look at the logs!"
+                    </button>
+                </column>
+                <column s:padding="25px" s:margin="5px" s:background-color="black">
+                    <span>"Row 1 Column 2"</span>
+                    <button on:press=|ctx| info!("I was pressed at {}", ctx.time().elapsed_seconds())>
+                        "2. Press me and look at the logs!"
+                    </button>
+                </column>
+            </row>
+            <row>
+                <column s:padding="25px" s:margin="5px" s:background-color="black">
+                    <span>"Row 2 Column 1"</span>
+                    <button on:press=|ctx| info!("I was pressed at {}", ctx.time().elapsed_seconds())>
+                        "3. Press me and look at the logs!"
+                    </button>
+                </column>
+                <column s:padding="25px" s:margin="5px" s:background-color="white">
+                    <span>"Row 2 Column 2"</span>
+                    <button on:press=|ctx| info!("I was pressed at {}", ctx.time().elapsed_seconds())>
+                        "4. Press me and look at the logs!"
+                    </button>
+                </column>
+            </row>
+            <row s:background-color="red" s:width="100%">
+                <center s:width="fit-content" s:background-color="blue">
+                    <span>"Centered text"</span>
+                </center>
+            </row>
+        </body>
+    });
+    commands.add(StyleSheet::parse(
+        r#"
+        body: {
+            padding: 20px;
+            flex-direction: column;
+            justify-content: center;
+            align-content: center;
+            align-items: center;
+        }
+        .counter {
+            max-width: 200px;
+            justify-content: space-between;
+        }
+    "#,
+    ));
+}
+
+fn greet(mut greets: Query<&mut Greet, Changed<Greet>>) {
+    for mut greet in greets.iter_mut() {
+        greet.message = format!("Count: {}", greet.counter);
+    }
+}
+
+fn debug_my_event(mut events: EventReader<MyEvent>) {
+    for event in events.iter() {
+        info!("MyEvent emitted at {:0.2}", event.emited_at);
+    }
+}


### PR DESCRIPTION
This adds a layout plugin with basic `row`,`column`,`center`, and `wrap` implementations along with an example in `layout-widgets`. 

Todo:

- [ ] Complete attribute implementations
- [ ] Check wrap functionality
- [ ] Integrate into other examples

Note: I'm relatively new to Rust and bevy as well.