### PR TITLE
Fix multi window bug

### DIFF
--- a/crates/belly_widgets/src/follow.rs
+++ b/crates/belly_widgets/src/follow.rs
@@ -46,14 +46,15 @@ fn follow_system(
     mut commands: Commands,
     windows: Query<&Window>,
 ) {
-    let window = windows.single();
-    for (entity, follow, mut style, node) in follows.iter_mut() {
-        let Ok(tr) = transforms.get(follow.target) else {
+    for window in windows.iter() {
+        for (entity, follow, mut style, node) in follows.iter_mut() {
+            let Ok(tr) = transforms.get(follow.target) else {
             commands.entity(entity).despawn_recursive();
             continue
         };
-        let pos = tr.translation();
-        style.left = Val::Px((pos.x + window.width() * 0.5 - 0.5 * node.size().x).round());
-        style.top = Val::Px((window.height() * 0.5 - pos.y - 0.5 * node.size().y).round());
+            let pos = tr.translation();
+            style.left = Val::Px((pos.x + window.width() * 0.5 - 0.5 * node.size().x).round());
+            style.top = Val::Px((window.height() * 0.5 - pos.y - 0.5 * node.size().y).round());
+        }
     }
 }


### PR DESCRIPTION
closes #73 
branch: bevy-0.11
when you add second window 
```rust
commands.spawn(Window::default());
```
you have such error
```
RUST_BACKTRACE=full cargo run --example button
    Blocking waiting for file lock on build directory
   Compiling belly_widgets v0.2.0 (/home/nick/Kvadratu/belly/crates/belly_widgets)
   Compiling belly v0.2.0 (/home/nick/Kvadratu/belly)
    Finished dev [unoptimized + debuginfo] target(s) in 27.90s
     Running `target/debug/examples/button`
2023-09-10T19:21:10.423327Z  INFO bevy_winit::system: Creating new window "App" (0v0)
2023-09-10T19:21:10.423854Z  INFO winit::platform_impl::platform::x11::window: Guessed window scale factor: 1    
2023-09-10T19:21:11.070349Z  INFO bevy_render::renderer: AdapterInfo { name: "NVIDIA GeForce RTX 3060 Laptop GPU", vendor: 4318, device: 9568, device_type: DiscreteGpu, driver: "NVIDIA", driver_info: "535.104.05", backend: Vulkan }
2023-09-10T19:21:11.218483Z  INFO bevy_diagnostic::system_information_diagnostics_plugin::internal: SystemInfo { os: "Linux  Arch Linux", kernel: "6.4.12-arch1-1", cpu: "AMD Ryzen 5 5600H with Radeon Graphics", core_count: "6", memory: "7.6 GiB" }
thread 'Compute Task Pool (4)' panicked at 'called `Result::unwrap()` on an `Err` value: MultipleEntities("bevy_ecs::query::state::QueryState<&bevy_window::window::Window>")', crates/belly_widgets/src/follow.rs:49:26
stack backtrace:
   0:     0x5645c608f601 - std::backtrace_rs::backtrace::libunwind::trace::h782cc21a5acaf6cb
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
   1:     0x5645c608f601 - std::backtrace_rs::backtrace::trace_unsynchronized::hc579eb24ab204515
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:     0x5645c608f601 - std::sys_common::backtrace::_print_fmt::h7223525cfdbacda2
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys_common/backtrace.rs:65:5
   3:     0x5645c608f601 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::hbd7d55b7108d2ab8
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys_common/backtrace.rs:44:22
   4:     0x5645c60b5baf - core::fmt::rt::Argument::fmt::hb4f4a02b9bd9dd49
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/fmt/rt.rs:138:9
   5:     0x5645c60b5baf - core::fmt::write::h6d54cd7c9e155ec5
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/fmt/mod.rs:1094:21
   6:     0x5645c608cba1 - std::io::Write::write_fmt::h6a453a71c692f63b
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/io/mod.rs:1713:15
   7:     0x5645c608f415 - std::sys_common::backtrace::_print::h1cbaa8b42678f928
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys_common/backtrace.rs:47:5
   8:     0x5645c608f415 - std::sys_common::backtrace::print::h4ddf81241a51b337
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys_common/backtrace.rs:34:9
   9:     0x5645c6090a67 - std::panicking::default_hook::{{closure}}::hff91f1f484ade5cd
  10:     0x5645c6090854 - std::panicking::default_hook::h21f14afd59f7aef9
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:288:9
  11:     0x5645c6090f1c - std::panicking::rust_panic_with_hook::h45f66047b14c555c
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:705:13
  12:     0x5645c6090e17 - std::panicking::begin_panic_handler::{{closure}}::h49d1a88ef0908eb4
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:597:13
  13:     0x5645c608fa36 - std::sys_common::backtrace::__rust_end_short_backtrace::hccebf9e57f8cc425
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys_common/backtrace.rs:151:18
  14:     0x5645c6090b62 - rust_begin_unwind
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:593:5
  15:     0x5645c284edf3 - core::panicking::panic_fmt::h54ec9d0e3180a83d
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/panicking.rs:67:14
  16:     0x5645c284f383 - core::result::unwrap_failed::h1cd730365d65235f
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/result.rs:1651:5
  17:     0x5645c294b0cf - core::result::Result<T,E>::unwrap::h89476fec61756ebe
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/result.rs:1076:23
  18:     0x5645c299c6fd - bevy_ecs::system::query::Query<Q,F>::single::he4901cffbc19b42a
                               at /home/nick/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bevy_ecs-0.11.1/src/system/query.rs:1231:9
  19:     0x5645c2a50fc7 - belly_widgets::follow::follow_system::h05c396e1fee52dfd
                               at /home/nick/Kvadratu/belly/crates/belly_widgets/src/follow.rs:49:18
  20:     0x5645c293f05b - core::ops::function::FnMut::call_mut::he15fad9600f2e6b4
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/ops/function.rs:166:5
  21:     0x5645c2a49d8f - core::ops::function::impls::<impl core::ops::function::FnMut<A> for &mut F>::call_mut::h6f90b908c70d2df1
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/ops/function.rs:294:13
  22:     0x5645c29d021e - <Func as bevy_ecs::system::function_system::SystemParamFunction<fn(F0,F1,F2,F3) .> Out>>::run::call_inner::h68f656c75493f0f7
                               at /home/nick/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bevy_ecs-0.11.1/src/system/function_system.rs:622:21
  23:     0x5645c2a49c31 - <Func as bevy_ecs::system::function_system::SystemParamFunction<fn(F0,F1,F2,F3) .> Out>>::run::h8020450a7cb17314
                               at /home/nick/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bevy_ecs-0.11.1/src/system/function_system.rs:625:17
  24:     0x5645c29c8c06 - <bevy_ecs::system::function_system::FunctionSystem<Marker,F> as bevy_ecs::system::system::System>::run_unsafe::hf2ce683592bdbc87
                               at /home/nick/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bevy_ecs-0.11.1/src/system/function_system.rs:460:19
  25:     0x5645c5da6459 - bevy_ecs::schedule::executor::multi_threaded::MultiThreadedExecutor::spawn_system_task::{{closure}}::{{closure}}::h427dbea4e06fb709
                               at /home/nick/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bevy_ecs-0.11.1/src/schedule/executor/multi_threaded.rs:505:26
  26:     0x5645c5e51b69 - core::ops::function::FnOnce::call_once::hd7f72027ea2d3c0e
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/ops/function.rs:250:5
  27:     0x5645c5e60219 - <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::h7080b1c779c677e8
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/panic/unwind_safe.rs:271:9
  28:     0x5645c5d92c7f - std::panicking::try::do_call::h35473b8230fefd99
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:500:40
  29:     0x5645c5d9b8db - __rust_try
  30:     0x5645c5d9228e - std::panicking::try::h64e5abcb3be4cff3
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:464:19
  31:     0x5645c5db2c5a - std::panic::catch_unwind::h78cb8b14d28635eb
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panic.rs:142:14
  32:     0x5645c5da5e31 - bevy_ecs::schedule::executor::multi_threaded::MultiThreadedExecutor::spawn_system_task::{{closure}}::h5a2385bce0d764a5
                               at /home/nick/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bevy_ecs-0.11.1/src/schedule/executor/multi_threaded.rs:500:23
  33:     0x5645c5e5fc5b - <core::panic::unwind_safe::AssertUnwindSafe<F> as core::future::future::Future>::poll::h0f470a6192ea3da2
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/panic/unwind_safe.rs:296:9
  34:     0x5645c5deb6e1 - <futures_lite::future::CatchUnwind<F> as core::future::future::Future>::poll::{{closure}}::h7d16f59ca873a229
                               at /home/nick/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-lite-1.13.0/src/future.rs:626:42
  35:     0x5645c5e602e4 - <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::hd2df7c4251a1db42
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/panic/unwind_safe.rs:271:9
  36:     0x5645c5d92b3c - std::panicking::try::do_call::h264aa1d57413a838
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:500:40
  37:     0x5645c5d9b8db - __rust_try
  38:     0x5645c5d929f7 - std::panicking::try::hefdb7ca44e04a3ec
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:464:19
  39:     0x5645c5db2c2b - std::panic::catch_unwind::h667d4cc0105cf294
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panic.rs:142:14
  40:     0x5645c5deb009 - <futures_lite::future::CatchUnwind<F> as core::future::future::Future>::poll::h278e00976d7ca08c
                               at /home/nick/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-lite-1.13.0/src/future.rs:626:9
  41:     0x5645c5d908be - async_executor::Executor::spawn::{{closure}}::h70e8a6900398884e
                               at /home/nick/.cargo/registry/src/index.crates.io-6f17d22bba15001f/async-executor-1.5.1/src/lib.rs:145:20
  42:     0x5645c5e0d1ef - async_task::raw::RawTask<F,T,S,M>::run::hc8f8407486dd3157
                               at /home/nick/.cargo/registry/src/index.crates.io-6f17d22bba15001f/async-task-4.4.0/src/raw.rs:563:17
  43:     0x5645c5e8aefc - async_task::runnable::Runnable<M>::run::hbe0d6fb868fe390e
                               at /home/nick/.cargo/registry/src/index.crates.io-6f17d22bba15001f/async-task-4.4.0/src/runnable.rs:782:18
  44:     0x5645c5e8677e - async_executor::Executor::run::{{closure}}::{{closure}}::he3ff4ef34fa2f68e
                               at /home/nick/.cargo/registry/src/index.crates.io-6f17d22bba15001f/async-executor-1.5.1/src/lib.rs:236:21
  45:     0x5645c5e7b605 - <futures_lite::future::Or<F1,F2> as core::future::future::Future>::poll::h9ccdf000d4d86199
                               at /home/nick/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-lite-1.13.0/src/future.rs:529:33
  46:     0x5645c5e863a9 - async_executor::Executor::run::{{closure}}::h7227567247ba9cb0
                               at /home/nick/.cargo/registry/src/index.crates.io-6f17d22bba15001f/async-executor-1.5.1/src/lib.rs:243:32
  47:     0x5645c5e7a185 - futures_lite::future::block_on::{{closure}}::h3d36d0e7b825128d
                               at /home/nick/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-lite-1.13.0/src/future.rs:89:27
  48:     0x5645c5e7f01d - std::thread::local::LocalKey<T>::try_with::ha9d2a215615f2665
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/thread/local.rs:270:16
  49:     0x5645c5e7e664 - std::thread::local::LocalKey<T>::with::h2c24ea051537cde1
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/thread/local.rs:246:9
  50:     0x5645c5e79e4d - futures_lite::future::block_on::h96aabeb078fd7ee3
                               at /home/nick/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-lite-1.13.0/src/future.rs:79:5
  51:     0x5645c5e83872 - bevy_tasks::task_pool::TaskPool::new_internal::{{closure}}::{{closure}}::{{closure}}::{{closure}}::h83815ed28c6a333c
                               at /home/nick/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bevy_tasks-0.11.1/src/task_pool.rs:171:37
  52:     0x5645c5e84465 - std::panicking::try::do_call::h334da9f425723c4b
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:500:40
  53:     0x5645c5e8484b - __rust_try
  54:     0x5645c5e843c7 - std::panicking::try::heddc918a55ec6c39
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:464:19
  55:     0x5645c5e81d2e - std::panic::catch_unwind::hd6afbe3748279ca0
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panic.rs:142:14
  56:     0x5645c5e835be - bevy_tasks::task_pool::TaskPool::new_internal::{{closure}}::{{closure}}::{{closure}}::hde2ef7f26c29ded6
                               at /home/nick/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bevy_tasks-0.11.1/src/task_pool.rs:165:43
  57:     0x5645c5e7ed20 - std::thread::local::LocalKey<T>::try_with::h9e7de7c19b68b956
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/thread/local.rs:270:16
  58:     0x5645c5e7e75b - std::thread::local::LocalKey<T>::with::h9184bc720132479a
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/thread/local.rs:246:9
  59:     0x5645c5e833c5 - bevy_tasks::task_pool::TaskPool::new_internal::{{closure}}::{{closure}}::h468a61bfe6b50c4e
                               at /home/nick/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bevy_tasks-0.11.1/src/task_pool.rs:158:25
  60:     0x5645c5e81cd9 - std::sys_common::backtrace::__rust_begin_short_backtrace::ha6953e9ecbbd73ca
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys_common/backtrace.rs:135:18
  61:     0x5645c5e80df1 - std::thread::Builder::spawn_unchecked_::{{closure}}::{{closure}}::hd82e5cd46f94a865
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/thread/mod.rs:529:17
  62:     0x5645c5e73661 - <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::h5be50a4f92553b69
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/panic/unwind_safe.rs:271:9
  63:     0x5645c5e8455a - std::panicking::try::do_call::hfe1f17940d6887ef
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:500:40
  64:     0x5645c5e8484b - __rust_try
  65:     0x5645c5e84202 - std::panicking::try::h2ad24536b8e79576
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:464:19
  66:     0x5645c5e80c1d - std::panic::catch_unwind::h2ecad5b7d9812004
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panic.rs:142:14
  67:     0x5645c5e80c1d - std::thread::Builder::spawn_unchecked_::{{closure}}::h15938ba5a1004ec1
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/thread/mod.rs:528:30
  68:     0x5645c5e77e5f - core::ops::function::FnOnce::call_once{{vtable.shim}}::hefa136ac2faa1ee2
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/ops/function.rs:250:5
  69:     0x5645c6094105 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::he3e5dbdfabe0b668
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/alloc/src/boxed.rs:1985:9
  70:     0x5645c6094105 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h246f7c7964633611
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/alloc/src/boxed.rs:1985:9
  71:     0x5645c6094105 - std::sys::unix::thread::Thread::new::thread_start::hadf9e3501ff0df23
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys/unix/thread.rs:108:17
  72:     0x7f12ef88c9eb - <unknown>
  73:     0x7f12ef910dfc - <unknown>
  74:                0x0 - <unknown>
Encountered a panic in system `belly_widgets::follow::follow_system`!
Encountered a panic in system `bevy_app::main_schedule::Main::run_main`!
```

this error cos by crates/belly_widgets/src/follow.rs follow_system
```rust
fn follow_system(
    mut follows: Query<(Entity, &Follow, &mut Style, &Node)>,
    transforms: Query<&GlobalTransform>,
    mut commands: Commands,
    windows: Query<&Window>,
) {
    let window = windows.single();
    for (entity, follow, mut style, node) in follows.iter_mut() {
        let Ok(tr) = transforms.get(follow.target) else {
            commands.entity(entity).despawn_recursive();
            continue
        };
        let pos = tr.translation();
        style.left = Val::Px((pos.x + window.width() * 0.5 - 0.5 * node.size().x).round());
        style.top = Val::Px((window.height() * 0.5 - pos.y - 0.5 * node.size().y).round());
    }
}
```
windows.single() make an error

the awfull(idk) solution its to iterate through all
```rust
fn follow_system(
    mut follows: Query<(Entity, &Follow, &mut Style, &Node)>,
    transforms: Query<&GlobalTransform>,
    mut commands: Commands,
    windows: Query<&Window>,
) {
    for window in windows.iter() {
        for (entity, follow, mut style, node) in follows.iter_mut() {
            let Ok(tr) = transforms.get(follow.target) else {
            commands.entity(entity).despawn_recursive();
            continue
        };
            let pos = tr.translation();
            style.left = Val::Px((pos.x + window.width() * 0.5 - 0.5 * node.size().x).round());
            style.top = Val::Px((window.height() * 0.5 - pos.y - 0.5 * node.size().y).round());
        }
    }
}
```
it fixed an error